### PR TITLE
Json Serializer Implementation

### DIFF
--- a/crates/odrl/src/functions/json_parser.rs
+++ b/crates/odrl/src/functions/json_parser.rs
@@ -114,7 +114,7 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for perm in permissions {
                         if perm.get("assigner").is_some() {
                             let assigner_uid = perm.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let offer_policy: Policy = Policy::OfferPolicy(OfferPolicy::new(policy_uid, assigner, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = offer_policy;
                             break;
@@ -125,7 +125,7 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for proh in prohibitions {
                         if proh.get("assigner").is_some() {
                             let assigner_uid = proh.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let offer_policy: Policy = Policy::OfferPolicy(OfferPolicy::new(policy_uid, assigner, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = offer_policy;
                             break;
@@ -136,7 +136,7 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for duty in duties {
                         if duty.get("assigner").is_some() {
                             let assigner_uid = duty.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let offer_policy: Policy = Policy::OfferPolicy(OfferPolicy::new(policy_uid, assigner, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = offer_policy;
                             break;
@@ -147,7 +147,7 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for obli in obligations {
                         if obli.get("assigner").is_some() {
                             let assigner_uid = obli.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let offer_policy: Policy = Policy::OfferPolicy(OfferPolicy::new(policy_uid, assigner, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = offer_policy;
                             break;
@@ -156,7 +156,7 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                 }
             } else if policy.is_array() {
                 let assigner_uid = policy.get("assigner").ok_or("No assigner field").unwrap();
-                let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                 let offer_policy: Policy = Policy::OfferPolicy(OfferPolicy::new(policy_uid, assigner, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                 policy_obj = offer_policy;
             }
@@ -168,9 +168,9 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for perm in permissions {
                         if perm.get("assigner").is_some() && perm.get("assignee").is_some() {
                             let assigner_uid = perm.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let assignee_uid = perm.get("assignee").ok_or("No assignee field").unwrap();
-                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee);
+                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee, None);
                             let agreement_policy: Policy = Policy::AgreementPolicy(AgreementPolicy::new(policy_uid, assigner, assignee, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = agreement_policy;
                             break;
@@ -181,9 +181,9 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for proh in prohibitions {
                         if proh.get("assigner").is_some() && proh.get("assignee").is_some() {
                             let assigner_uid = proh.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let assignee_uid = proh.get("assignee").ok_or("No assignee field").unwrap();
-                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee);
+                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee, None);
                             let agreement_policy: Policy = Policy::AgreementPolicy(AgreementPolicy::new(policy_uid, assigner, assignee, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = agreement_policy;
                             break;
@@ -194,9 +194,9 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for duty in duties {
                         if duty.get("assigner").is_some() && duty.get("assignee").is_some() {
                             let assigner_uid = duty.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let assignee_uid = duty.get("assignee").ok_or("No assignee field").unwrap();
-                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee);
+                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee, None);
                             let agreement_policy: Policy = Policy::AgreementPolicy(AgreementPolicy::new(policy_uid, assigner, assignee, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = agreement_policy;
                             break;
@@ -207,9 +207,9 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                     for obli in obligations {
                         if obli.get("assigner").is_some() && obli.get("assignee").is_some() {
                             let assigner_uid = obli.get("assigner").ok_or("No assigner field").unwrap();
-                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner);
+                            let assigner = Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None);
                             let assignee_uid = obli.get("assignee").ok_or("No assignee field").unwrap();
-                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee);
+                            let assignee = Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee, None);
                             let agreement_policy: Policy = Policy::AgreementPolicy(AgreementPolicy::new(policy_uid, assigner, assignee, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                             policy_obj = agreement_policy;
                             break;
@@ -218,9 +218,9 @@ fn parse_policy(policy: &Value) -> Result<Policy> {
                 }
             } else if policy.is_array() {
                 let assigner_uid = policy.get("assigner").ok_or("No assigner field").unwrap();
-                let assigner = Party::new(Some(assigner_uid.to_string()), vec![], Function::Assigner);
+                let assigner = Party::new(Some(assigner_uid.to_string()), vec![], Function::Assigner, None);
                 let assignee_uid = policy.get("assignee").ok_or("No assignee field").unwrap();
-                let assignee = Party::new(Some(assignee_uid.to_string()), vec![], Function::Assignee);
+                let assignee = Party::new(Some(assignee_uid.to_string()), vec![], Function::Assignee, None);
                 let agreement_policy: Policy = Policy::AgreementPolicy(AgreementPolicy::new(policy_uid, assigner, assignee, rules_vec, profiles_vec, inherit_from_vec, conflict_term, vec![]));
                 policy_obj = agreement_policy;
             }
@@ -274,13 +274,13 @@ fn parse_rule(rule_type: &str, rule: &Value) -> Result<Rule> {
     let assignee: Option<Party>;
 
     if let Some(assigner_uid) = rule.get("assigner") {
-        assigner = Some(Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner));
+        assigner = Some(Party::new(Some(assigner_uid.to_string().replace("\"", "")), vec![], Function::Assigner, None));
     } else {
         assigner = None;
     }
 
     if let Some(assignee_uid) = rule.get("assignee") {
-        assignee = Some(Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee));
+        assignee = Some(Party::new(Some(assignee_uid.to_string().replace("\"", "")), vec![], Function::Assignee, None));
     } else {
         assignee = None;
     }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -4,6 +4,7 @@ use crate::model::rule::{Rule, Permission, Prohibition, Obligation, Duty};
 use crate::model::action::{Action, Refinements};
 use crate::model::constraint::{Constraint, LeftOperand, RightOperand};
 use crate::model::party::Party;
+use crate::model::asset::Asset;
 
 impl Serialize for SetPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -402,16 +403,22 @@ fn serialize_party(party: &Party) -> serde_json::Map<String, serde_json::Value> 
 }
 
 
+fn serialize_target(target: &Asset) -> serde_json::Map<String, serde_json::Value> {
+    let mut target_map = serde_json::Map::new();
+    if let Some(target_type) = &target.edc_type {
+        target_map.insert("@type".to_string(), serde_json::json!(target_type));
+    }
+    if let Some(target_uid) = &target.uid {
+        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
+    }
+    target_map
+}
+
+
 fn serialize_permission(permission: &Permission) -> serde_json::Map<String, serde_json::Value> {
     let mut permission_map = serde_json::Map::new();
 
-    let mut target_map = serde_json::Map::new();
-    if let Some(target_type) = &permission.target.edc_type {
-        target_map.insert("@type".to_string(), serde_json::json!(target_type));
-    }
-    if let Some(target_uid) = &permission.target.uid {
-        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
-    }
+    let target_map = serialize_target(&permission.target);
     if target_map.len() > 1 {
         permission_map.insert("target".to_string(), serde_json::Value::Object(target_map));
     } else {
@@ -460,13 +467,7 @@ fn serialize_permission(permission: &Permission) -> serde_json::Map<String, serd
 fn serialize_prohibition(prohibition: &Prohibition) -> serde_json::Map<String, serde_json::Value> {
     let mut prohibition_map = serde_json::Map::new();
 
-    let mut target_map = serde_json::Map::new();
-    if let Some(target_type) = &prohibition.target.edc_type {
-        target_map.insert("@type".to_string(), serde_json::json!(target_type));
-    }
-    if let Some(target_uid) = &prohibition.target.uid {
-        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
-    }
+    let target_map = serialize_target(&prohibition.target);
     if target_map.len() > 1 {
         prohibition_map.insert("target".to_string(), serde_json::Value::Object(target_map));
     } else {
@@ -515,13 +516,7 @@ fn serialize_prohibition(prohibition: &Prohibition) -> serde_json::Map<String, s
 fn serialize_obligation(obligation: &Obligation) -> serde_json::Map<String, serde_json::Value> {
     let mut obligation_map = serde_json::Map::new();
 
-    let mut target_map = serde_json::Map::new();
-    if let Some(target_type) = &obligation.target.edc_type {
-        target_map.insert("@type".to_string(), serde_json::json!(target_type));
-    }
-    if let Some(target_uid) = &obligation.target.uid {
-        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
-    }
+    let target_map = serialize_target(&obligation.target);
     if target_map.len() > 1 {
         obligation_map.insert("target".to_string(), serde_json::Value::Object(target_map));
     } else {

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -60,14 +60,50 @@ impl Serialize for SetPolicy {
                 }
 
                 if let Some(assigner) = &p.assigner {
+                    let mut assigner_map = serde_json::Map::new();
+                    if let Some(assigner_type) = &assigner.r#type {
+                        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                    }
                     if let Some(assigner_uid) = &assigner.uid {
-                        permission_map.insert("assigner".to_string(), serde_json::json!(assigner_uid));
+                        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                    }
+                    if assigner.part_of.len() > 0 {
+                        if assigner.part_of.len() == 1 {
+                            assigner_map.insert("partOf".to_string(), serde_json::json!(assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
+                        } else {
+                            // Collect all PartyCollection.source into a vec
+                            let part_of: Vec<_> = assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
+                        }
+                    }
+                    if assigner_map.len() > 1 {
+                        permission_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+                    } else {
+                        permission_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
                     }
                 }
 
                 if let Some(assignee) = &p.assignee {
-                    if let Some(assignee_uid) = &assignee.uid {
-                        permission_map.insert("assignee".to_string(), serde_json::json!(assignee_uid));
+                    let mut assignee_map = serde_json::Map::new();
+                    if let Some(assigner_type) = &assignee.r#type {
+                        assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                    }
+                    if let Some(assigner_uid) = &assignee.uid {
+                        assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                    }
+                    if assignee.part_of.len() > 0 {
+                        if assignee.part_of.len() == 1 {
+                            assignee_map.insert("partOf".to_string(), serde_json::json!(assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
+                        } else {
+                            // Collect all PartyCollection.source into a vec
+                            let part_of: Vec<_> = assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                            assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
+                        }
+                    }
+                    if assignee_map.len() > 1 {
+                        permission_map.insert("assigner".to_string(), serde_json::Value::Object(assignee_map));
+                    } else {
+                        permission_map.insert("assigner".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
                     }
                 }
 

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -382,7 +382,7 @@ fn serialize_duty(duties: &Vec<Duty>) -> Vec<serde_json::Map<String, serde_json:
 
 fn serialize_party(party: &Party) -> serde_json::Map<String, serde_json::Value> {
     let mut assigner_map = serde_json::Map::new();
-    if let Some(assigner_type) = &party.r#type {
+    if let Some(assigner_type) = &party.party_type {
         assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
     }
     if let Some(assigner_uid) = &party.uid {

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -1,9 +1,10 @@
 // TODO: Serialize rules manually since they are represented as arrays of permissions, prohibitions and obligations
 
-use std::ops::Deref;
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use crate::model::policy::{AgreementPolicy, OfferPolicy, SetPolicy};
-use crate::model::rule::{Rule, Permission, Prohibition, Duty, Obligation};
+use crate::model::rule::{Rule, Permission, Prohibition, Obligation};
+use crate::model::action::Refinements;
+use crate::model::constraint::{LeftOperand, RightOperand};
 
 impl Serialize for SetPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -114,7 +115,61 @@ impl Serialize for SetPolicy {
                     let mut action_map = serde_json::Map::new();
                     action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
                     if let Some(refinements) = &p.action.refinements {
-                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                        // differentiate between constraints and logical constraints
+                        match refinements {
+                            Refinements::Constraints(constraints) => {
+                                let mut serialized_constraints = Vec::new();
+                                for constraint in constraints {
+                                    let mut constraint_map = serde_json::Map::new();
+                                    // differentiate between literal and iri operands
+                                    match &constraint.left_operand {
+                                        LeftOperand::Literal(literal) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        LeftOperand::IRI(iri) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        LeftOperand::Reference(reference) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                                    // differentiate between literal and iri operands
+                                    match &constraint.right_operand {
+                                        RightOperand::Literal(literal) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        RightOperand::IRI(iri) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        RightOperand::Reference(reference) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    if let Some(data_type) = &constraint.data_type {
+                                        constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                                    }
+                                    if let Some(unit) = &constraint.unit {
+                                        constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                                    }
+                                    if !constraint.status.is_empty() {
+                                        constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                                    }
+                                    serialized_constraints.push(constraint_map);
+                                }
+                                action_map.insert("refinement".to_string(), serde_json::json!(serialized_constraints));
+                            },
+                            Refinements::LogicalConstraints(logical_constraints) => {
+                                for logical_constraint in logical_constraints {
+                                    let mut logical_constraint_map = serde_json::Map::new();
+                                    if let Some(operand) = &logical_constraint.operand {
+                                        logical_constraint_map.insert(serde_json::json!(operand.0).to_string().replace("\"", ""), serde_json::json!(operand.1));
+                                    }
+                                    let serialized_logical_constraint = serde_json::json!(logical_constraint_map);
+                                    action_map.insert("refinement".to_string(), serialized_logical_constraint);
+                                }
+                            }
+                        }
                     }
                     if let Some(included_in) = &p.action.included_in {
                         action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
@@ -209,7 +264,61 @@ impl Serialize for SetPolicy {
                     let mut action_map = serde_json::Map::new();
                     action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
                     if let Some(refinements) = &p.action.refinements {
-                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                        // differentiate between constraints and logical constraints
+                        match refinements {
+                            Refinements::Constraints(constraints) => {
+                                let mut serialized_constraints = Vec::new();
+                                for constraint in constraints {
+                                    let mut constraint_map = serde_json::Map::new();
+                                    // differentiate between literal and iri operands
+                                    match &constraint.left_operand {
+                                        LeftOperand::Literal(literal) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        LeftOperand::IRI(iri) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        LeftOperand::Reference(reference) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                                    // differentiate between literal and iri operands
+                                    match &constraint.right_operand {
+                                        RightOperand::Literal(literal) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        RightOperand::IRI(iri) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        RightOperand::Reference(reference) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    if let Some(data_type) = &constraint.data_type {
+                                        constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                                    }
+                                    if let Some(unit) = &constraint.unit {
+                                        constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                                    }
+                                    if !constraint.status.is_empty() {
+                                        constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                                    }
+                                    serialized_constraints.push(constraint_map);
+                                }
+                                action_map.insert("refinement".to_string(), serde_json::json!(serialized_constraints));
+                            },
+                            Refinements::LogicalConstraints(logical_constraints) => {
+                                for logical_constraint in logical_constraints {
+                                    let mut logical_constraint_map = serde_json::Map::new();
+                                    if let Some(operand) = &logical_constraint.operand {
+                                        logical_constraint_map.insert(serde_json::json!(operand.0).to_string().replace("\"", ""), serde_json::json!(operand.1));
+                                    }
+                                    let serialized_logical_constraint = serde_json::json!(logical_constraint_map);
+                                    action_map.insert("refinement".to_string(), serialized_logical_constraint);
+                                }
+                            }
+                        }
                     }
                     if let Some(included_in) = &p.action.included_in {
                         action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
@@ -298,7 +407,61 @@ impl Serialize for SetPolicy {
                     let mut action_map = serde_json::Map::new();
                     action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
                     if let Some(refinements) = &p.action.refinements {
-                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                        // differentiate between constraints and logical constraints
+                        match refinements {
+                            Refinements::Constraints(constraints) => {
+                                let mut serialized_constraints = Vec::new();
+                                for constraint in constraints {
+                                    let mut constraint_map = serde_json::Map::new();
+                                    // differentiate between literal and iri operands
+                                    match &constraint.left_operand {
+                                        LeftOperand::Literal(literal) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        LeftOperand::IRI(iri) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        LeftOperand::Reference(reference) => {
+                                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                                    // differentiate between literal and iri operands
+                                    match &constraint.right_operand {
+                                        RightOperand::Literal(literal) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                                        },
+                                        RightOperand::IRI(iri) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                                        }
+                                        RightOperand::Reference(reference) => {
+                                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                                        }
+                                    }
+                                    if let Some(data_type) = &constraint.data_type {
+                                        constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                                    }
+                                    if let Some(unit) = &constraint.unit {
+                                        constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                                    }
+                                    if !constraint.status.is_empty() {
+                                        constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                                    }
+                                    serialized_constraints.push(constraint_map);
+                                }
+                                action_map.insert("refinement".to_string(), serde_json::json!(serialized_constraints));
+                            },
+                            Refinements::LogicalConstraints(logical_constraints) => {
+                                for logical_constraint in logical_constraints {
+                                    let mut logical_constraint_map = serde_json::Map::new();
+                                    if let Some(operand) = &logical_constraint.operand {
+                                        logical_constraint_map.insert(serde_json::json!(operand.0).to_string().replace("\"", ""), serde_json::json!(operand.1));
+                                    }
+                                    let serialized_logical_constraint = serde_json::json!(logical_constraint_map);
+                                    action_map.insert("refinement".to_string(), serialized_logical_constraint);
+                                }
+                            }
+                        }
                     }
                     if let Some(included_in) = &p.action.included_in {
                         action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
@@ -321,8 +484,61 @@ impl Serialize for SetPolicy {
                         let mut action_map = serde_json::Map::new();
                         action_map.insert("name".to_string(), serde_json::json!(d.action.name.clone()));
                         if let Some(refinements) = &d.action.refinements {
-                            // TODO remove some of the field names
-                            action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                            // differentiate between constraints and logical constraints
+                            match refinements {
+                                Refinements::Constraints(constraints) => {
+                                    let mut serialized_constraints = Vec::new();
+                                    for constraint in constraints {
+                                        let mut constraint_map = serde_json::Map::new();
+                                        // differentiate between literal and iri operands
+                                        match &constraint.left_operand {
+                                            LeftOperand::Literal(literal) => {
+                                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                                            },
+                                            LeftOperand::IRI(iri) => {
+                                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                                            }
+                                            LeftOperand::Reference(reference) => {
+                                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                                            }
+                                        }
+                                        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                                        // differentiate between literal and iri operands
+                                        match &constraint.right_operand {
+                                            RightOperand::Literal(literal) => {
+                                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                                            },
+                                            RightOperand::IRI(iri) => {
+                                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                                            }
+                                            RightOperand::Reference(reference) => {
+                                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                                            }
+                                        }
+                                        if let Some(data_type) = &constraint.data_type {
+                                            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                                        }
+                                        if let Some(unit) = &constraint.unit {
+                                            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                                        }
+                                        if !constraint.status.is_empty() {
+                                            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                                        }
+                                        serialized_constraints.push(constraint_map);
+                                    }
+                                    action_map.insert("refinement".to_string(), serde_json::json!(serialized_constraints));
+                                },
+                                Refinements::LogicalConstraints(logical_constraints) => {
+                                    for logical_constraint in logical_constraints {
+                                        let mut logical_constraint_map = serde_json::Map::new();
+                                        if let Some(operand) = &logical_constraint.operand {
+                                            logical_constraint_map.insert(serde_json::json!(operand.0).to_string().replace("\"", ""), serde_json::json!(operand.1));
+                                        }
+                                        let serialized_logical_constraint = serde_json::json!(logical_constraint_map);
+                                        action_map.insert("refinement".to_string(), serialized_logical_constraint);
+                                    }
+                                }
+                            }
                         }
                         if let Some(included_in) = &d.action.included_in {
                             action_map.insert("includedIn".to_string(), serde_json::json!(included_in));

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -347,7 +347,7 @@ fn serialize_prohibition(prohibition: &Prohibition) -> serde_json::Map<String, s
 
     if prohibition.remedies.len() != 0 {
         let serialized_duties = serialize_duty(&prohibition.remedies);
-        prohibition.insert("remedy".to_string(), serde_json::json!(serialized_duties));
+        prohibition_map.insert("remedy".to_string(), serde_json::json!(serialized_duties));
     }
 
     prohibition_map

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Serializer, ser::SerializeStruct};
 use crate::model::policy::{AgreementPolicy, OfferPolicy, SetPolicy};
 use crate::model::rule::{Rule, Permission, Prohibition, Obligation};
 use crate::model::action::{Action, Refinements};
-use crate::model::constraint::{LeftOperand, RightOperand};
+use crate::model::constraint::{Constraint, LeftOperand, RightOperand};
 
 impl Serialize for SetPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -117,45 +117,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if p.constraints.len() != 0 {
-                    let mut serialized_constraints = Vec::new();
-                    for constraint in &p.constraints {
-                        let mut constraint_map = serde_json::Map::new();
-                        // differentiate between literal and iri operands
-                        match &constraint.left_operand {
-                            LeftOperand::Literal(literal) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
-                            },
-                            LeftOperand::IRI(iri) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
-                            }
-                            LeftOperand::Reference(reference) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
-                            }
-                        }
-                        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
-                        // differentiate between literal and iri operands
-                        match &constraint.right_operand {
-                            RightOperand::Literal(literal) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
-                            },
-                            RightOperand::IRI(iri) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
-                            }
-                            RightOperand::Reference(reference) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
-                            }
-                        }
-                        if let Some(data_type) = &constraint.data_type {
-                            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
-                        }
-                        if let Some(unit) = &constraint.unit {
-                            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
-                        }
-                        if !constraint.status.is_empty() {
-                            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
-                        }
-                        serialized_constraints.push(constraint_map);
-                    }
+                    let serialized_constraints = serialize_constraint(&p.constraints);
                     permission_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
                 }
 
@@ -245,45 +207,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if p.constraints.len() != 0 {
-                    let mut serialized_constraints = Vec::new();
-                    for constraint in &p.constraints {
-                        let mut constraint_map = serde_json::Map::new();
-                        // differentiate between literal and iri operands
-                        match &constraint.left_operand {
-                            LeftOperand::Literal(literal) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
-                            },
-                            LeftOperand::IRI(iri) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
-                            }
-                            LeftOperand::Reference(reference) => {
-                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
-                            }
-                        }
-                        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
-                        // differentiate between literal and iri operands
-                        match &constraint.right_operand {
-                            RightOperand::Literal(literal) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
-                            },
-                            RightOperand::IRI(iri) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
-                            }
-                            RightOperand::Reference(reference) => {
-                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
-                            }
-                        }
-                        if let Some(data_type) = &constraint.data_type {
-                            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
-                        }
-                        if let Some(unit) = &constraint.unit {
-                            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
-                        }
-                        if !constraint.status.is_empty() {
-                            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
-                        }
-                        serialized_constraints.push(constraint_map);
-                    }
+                    let serialized_constraints = serialize_constraint(&p.constraints);
                     prohibition_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
                 }
 
@@ -455,45 +379,7 @@ fn serialize_action(action: &Action) -> serde_json::Map<String, serde_json::Valu
         // differentiate between constraints and logical constraints
         match refinements {
             Refinements::Constraints(constraints) => {
-                let mut serialized_constraints = Vec::new();
-                for constraint in constraints {
-                    let mut constraint_map = serde_json::Map::new();
-                    // differentiate between literal and iri operands
-                    match &constraint.left_operand {
-                        LeftOperand::Literal(literal) => {
-                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
-                        },
-                        LeftOperand::IRI(iri) => {
-                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
-                        }
-                        LeftOperand::Reference(reference) => {
-                            constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
-                        }
-                    }
-                    constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
-                    // differentiate between literal and iri operands
-                    match &constraint.right_operand {
-                        RightOperand::Literal(literal) => {
-                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
-                        },
-                        RightOperand::IRI(iri) => {
-                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
-                        }
-                        RightOperand::Reference(reference) => {
-                            constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
-                        }
-                    }
-                    if let Some(data_type) = &constraint.data_type {
-                        constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
-                    }
-                    if let Some(unit) = &constraint.unit {
-                        constraint_map.insert("unit".to_string(), serde_json::json!(unit));
-                    }
-                    if !constraint.status.is_empty() {
-                        constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
-                    }
-                    serialized_constraints.push(constraint_map);
-                }
+                let serialized_constraints = serialize_constraint(constraints);
                 action_map.insert("refinement".to_string(), serde_json::json!(serialized_constraints));
             },
             Refinements::LogicalConstraints(logical_constraints) => {
@@ -515,4 +401,49 @@ fn serialize_action(action: &Action) -> serde_json::Map<String, serde_json::Valu
         action_map.insert("implies".to_string(), serde_json::json!(action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
     }
     action_map
+}
+
+
+fn serialize_constraint(constraints: &Vec<Constraint>) -> Vec<serde_json::Map<String, serde_json::Value>> {
+    let mut serialized_constraints = Vec::new();
+    for constraint in constraints {
+        let mut constraint_map = serde_json::Map::new();
+        // differentiate between literal and iri operands
+        match &constraint.left_operand {
+            LeftOperand::Literal(literal) => {
+                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+            },
+            LeftOperand::IRI(iri) => {
+                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+            }
+            LeftOperand::Reference(reference) => {
+                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+            }
+        }
+        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+        // differentiate between literal and iri operands
+        match &constraint.right_operand {
+            RightOperand::Literal(literal) => {
+                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+            },
+            RightOperand::IRI(iri) => {
+                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+            }
+            RightOperand::Reference(reference) => {
+                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+            }
+        }
+        if let Some(data_type) = &constraint.data_type {
+            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+        }
+        if let Some(unit) = &constraint.unit {
+            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+        }
+        if !constraint.status.is_empty() {
+            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+        }
+        serialized_constraints.push(constraint_map);
+    }
+
+    serialized_constraints
 }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -5,6 +5,7 @@ use crate::model::policy::{AgreementPolicy, OfferPolicy, SetPolicy};
 use crate::model::rule::{Rule, Permission, Prohibition, Obligation};
 use crate::model::action::{Action, Refinements};
 use crate::model::constraint::{Constraint, LeftOperand, RightOperand};
+use crate::model::party::Party;
 
 impl Serialize for SetPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -62,22 +63,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if let Some(assigner) = &p.assigner {
-                    let mut assigner_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assigner.r#type {
-                        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assigner.uid {
-                        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assigner.part_of.len() > 0 {
-                        if assigner.part_of.len() == 1 {
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
+                    let assigner_map = serialize_party(assigner);
                     if assigner_map.len() > 1 {
                         permission_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
                     } else {
@@ -86,22 +72,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if let Some(assignee) = &p.assignee {
-                    let mut assignee_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assignee.r#type {
-                        assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assignee.uid {
-                        assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assignee.part_of.len() > 0 {
-                        if assignee.part_of.len() == 1 {
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
+                    let assignee_map = serialize_party(assignee);
                     if assignee_map.len() > 1 {
                         permission_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
                     } else {
@@ -152,22 +123,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if let Some(assigner) = &p.assigner {
-                    let mut assigner_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assigner.r#type {
-                        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assigner.uid {
-                        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assigner.part_of.len() > 0 {
-                        if assigner.part_of.len() == 1 {
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
+                    let assigner_map = serialize_party(assigner);
                     if assigner_map.len() > 1 {
                         prohibition_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
                     } else {
@@ -176,22 +132,7 @@ impl Serialize for SetPolicy {
                 }
 
                 if let Some(assignee) = &p.assignee {
-                    let mut assignee_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assignee.r#type {
-                        assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assignee.uid {
-                        assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assignee.part_of.len() > 0 {
-                        if assignee.part_of.len() == 1 {
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
+                    let assignee_map = serialize_party(assignee);
                     if assignee_map.len() > 1 {
                         prohibition_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
                     } else {
@@ -241,42 +182,14 @@ impl Serialize for SetPolicy {
                     obligation_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
                 }
 
-                let mut assigner_map = serde_json::Map::new();
-                if let Some(assigner_type) = &p.assigner.r#type {
-                    assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                }
-                assigner_map.insert("uid".to_string(), serde_json::json!(p.assigner.uid.as_ref().unwrap_or(&String::new())));
-                if p.assigner.part_of.len() > 0 {
-                    if p.assigner.part_of.len() == 1 {
-                        assigner_map.insert("partOf".to_string(), serde_json::json!(p.assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                    } else {
-                        // Collect all PartyCollection.source into a vec
-                        let part_of: Vec<_> = p.assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                        assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                    }
-                }
+                let assigner_map = serialize_party(&p.assigner);
                 if assigner_map.len() > 1 {
                     obligation_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
                 } else {
                     obligation_map.insert("assigner".to_string(), serde_json::json!(p.assigner.uid.as_ref().unwrap_or(&String::new())));
                 }
 
-                let mut assignee_map = serde_json::Map::new();
-                if let Some(assigner_type) = &p.assignee.r#type {
-                    assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                }
-                if let Some(assigner_uid) = &p.assignee.uid {
-                    assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                }
-                if p.assignee.part_of.len() > 0 {
-                    if p.assignee.part_of.len() == 1 {
-                        assignee_map.insert("partOf".to_string(), serde_json::json!(p.assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                    } else {
-                        // Collect all PartyCollection.source into a vec
-                        let part_of: Vec<_> = p.assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                        assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                    }
-                }
+                let assignee_map = serialize_party(&p.assignee);
                 if assignee_map.len() > 1 {
                     obligation_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
                 } else {
@@ -446,4 +359,26 @@ fn serialize_constraint(constraints: &Vec<Constraint>) -> Vec<serde_json::Map<St
     }
 
     serialized_constraints
+}
+
+
+fn serialize_party(party: &Party) -> serde_json::Map<String, serde_json::Value> {
+    let mut assigner_map = serde_json::Map::new();
+    if let Some(assigner_type) = &party.r#type {
+        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+    }
+    if let Some(assigner_uid) = &party.uid {
+        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+    }
+    if party.part_of.len() > 0 {
+        if party.part_of.len() == 1 {
+            assigner_map.insert("partOf".to_string(), serde_json::json!(party.part_of[0].source.as_ref().unwrap_or(&String::new())));
+        } else {
+            // Collect all PartyCollection.source into a vec
+            let part_of: Vec<_> = party.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
+        }
+    }
+
+    assigner_map
 }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -1,0 +1,93 @@
+// TODO: Serialize rules manually since they are represented as arrays of permissions, prohibitions and obligations
+
+use serde::{Serialize, Serializer, ser::SerializeStruct};
+use crate::model::policy::{AgreementPolicy, OfferPolicy, SetPolicy};
+use crate::model::rule::{Rule, Permission, Prohibition, Duty};
+
+impl Serialize for SetPolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        // docs.rs: len does not include fields which are skipped with SerializeStruct::skip_field.
+        let mut state = serializer.serialize_struct("SetPolicy", 5)?;
+        state.serialize_field("@type", "Set")?;
+        state.serialize_field("uid", &self.uid)?;
+        if !self.profiles.is_empty() {
+            if self.profiles.len() == 1 {
+                state.serialize_field("profile", &self.profiles[0])?;
+            } else {
+                state.serialize_field("profile", &self.profiles)?;
+            }
+        }
+        if !self.inherit_from.is_empty() {
+            if self.inherit_from.len() == 1 {
+                state.serialize_field("inheritFrom", &self.inherit_from[0])?;
+            } else {
+                state.serialize_field("inheritFrom", &self.inherit_from)?;
+            }
+        }
+        if let Some(conflict) = &self.conflict {
+            state.serialize_field("conflict", conflict)?;
+        }
+        if !self.obligation.is_empty() {
+            state.serialize_field("obligation", &self.obligation)?;
+        }
+
+        let permissions: Vec<&Permission> = self.rules.iter().filter_map(|rule| {
+            if let Rule::Permission(permission) = rule {
+                Some(permission)
+            } else {
+                None
+            }
+        }).collect();
+
+        if !permissions.is_empty() {
+            let serialized_permissions: Vec<_> = permissions.iter().map(|p| {
+                let mut permission_map = serde_json::Map::new();
+                permission_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
+                if let Some(assigner) = &p.assigner {
+                    if let Some(assigner_uid) = &assigner.uid {
+                        permission_map.insert("assigner".to_string(), serde_json::json!(assigner_uid));
+                    }
+                }
+                if let Some(assignee) = &p.assignee {
+                    if let Some(assignee_uid) = &assignee.uid {
+                        permission_map.insert("assignee".to_string(), serde_json::json!(assignee_uid));
+                    }
+                }
+                permission_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                serde_json::Value::Object(permission_map)
+            }).collect();
+            state.serialize_field("permission", &serialized_permissions)?;
+        }
+
+        // TODO: Serialize prohibitions and obligations
+
+        state.end()
+    }
+}
+
+
+impl Serialize for OfferPolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        // TODO
+        let mut state = serializer.serialize_struct("OfferPolicy", 7)?;
+        state.end()
+    }
+}
+
+
+impl Serialize for AgreementPolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        // TODO
+        let mut state = serializer.serialize_struct("AgreementPolicy", 8)?;
+        state.end()
+    }
+}

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -267,7 +267,7 @@ impl Serialize for SetPolicy {
 
                 serde_json::Value::Object(obligation_map)
             }).collect();
-            state.serialize_field("prohibition", &serialized_obligations)?;
+            state.serialize_field("obligation", &serialized_obligations)?;
         }
 
         state.end()

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -114,6 +114,86 @@ impl Serialize for SetPolicy {
             state.serialize_field("permission", &serialized_permissions)?;
         }
 
+        let prohibitions: Vec<&Prohibition> = self.rules.iter().filter_map(|rule| {
+            if let Rule::Prohibition(prohibition) = rule {
+                Some(prohibition)
+            } else {
+                None
+            }
+        }).collect();
+
+        if !prohibitions.is_empty() {
+            let serialized_prohibitions: Vec<_> = prohibitions.iter().map(|p| {
+                let mut prohibition_map = serde_json::Map::new();
+
+                let mut target_map = serde_json::Map::new();
+                if let Some(target_type) = &p.target.edc_type {
+                    target_map.insert("@type".to_string(), serde_json::json!(target_type));
+                }
+                if let Some(target_uid) = &p.target.uid {
+                    target_map.insert("uid".to_string(), serde_json::json!(target_uid));
+                }
+                if target_map.len() > 1 {
+                    prohibition_map.insert("target".to_string(), serde_json::Value::Object(target_map));
+                } else {
+                    prohibition_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
+                }
+
+                if let Some(assigner) = &p.assigner {
+                    let mut assigner_map = serde_json::Map::new();
+                    if let Some(assigner_type) = &assigner.r#type {
+                        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                    }
+                    if let Some(assigner_uid) = &assigner.uid {
+                        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                    }
+                    if assigner.part_of.len() > 0 {
+                        if assigner.part_of.len() == 1 {
+                            assigner_map.insert("partOf".to_string(), serde_json::json!(assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
+                        } else {
+                            // Collect all PartyCollection.source into a vec
+                            let part_of: Vec<_> = assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
+                        }
+                    }
+                    if assigner_map.len() > 1 {
+                        prohibition_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+                    } else {
+                        prohibition_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
+                    }
+                }
+
+                if let Some(assignee) = &p.assignee {
+                    let mut assignee_map = serde_json::Map::new();
+                    if let Some(assigner_type) = &assignee.r#type {
+                        assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                    }
+                    if let Some(assigner_uid) = &assignee.uid {
+                        assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                    }
+                    if assignee.part_of.len() > 0 {
+                        if assignee.part_of.len() == 1 {
+                            assignee_map.insert("partOf".to_string(), serde_json::json!(assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
+                        } else {
+                            // Collect all PartyCollection.source into a vec
+                            let part_of: Vec<_> = assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                            assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
+                        }
+                    }
+                    if assignee_map.len() > 1 {
+                        prohibition_map.insert("assigner".to_string(), serde_json::Value::Object(assignee_map));
+                    } else {
+                        prohibition_map.insert("assigner".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
+                    }
+                }
+
+                prohibition_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+
+                serde_json::Value::Object(prohibition_map)
+            }).collect();
+            state.serialize_field("prohibition", &serialized_prohibitions)?;
+        }
+
         // TODO: Serialize prohibitions and obligations
 
         state.end()

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -63,51 +63,7 @@ impl Serialize for SetPolicy {
 
         if !prohibitions.is_empty() {
             let serialized_prohibitions: Vec<_> = prohibitions.iter().map(|p| {
-                let mut prohibition_map = serde_json::Map::new();
-
-                let mut target_map = serde_json::Map::new();
-                if let Some(target_type) = &p.target.edc_type {
-                    target_map.insert("@type".to_string(), serde_json::json!(target_type));
-                }
-                if let Some(target_uid) = &p.target.uid {
-                    target_map.insert("uid".to_string(), serde_json::json!(target_uid));
-                }
-                if target_map.len() > 1 {
-                    prohibition_map.insert("target".to_string(), serde_json::Value::Object(target_map));
-                } else {
-                    prohibition_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
-                }
-
-                if let Some(assigner) = &p.assigner {
-                    let assigner_map = serialize_party(assigner);
-                    if assigner_map.len() > 1 {
-                        prohibition_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
-                    } else {
-                        prohibition_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
-                    }
-                }
-
-                if let Some(assignee) = &p.assignee {
-                    let assignee_map = serialize_party(assignee);
-                    if assignee_map.len() > 1 {
-                        prohibition_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
-                    } else {
-                        prohibition_map.insert("assignee".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
-                    }
-                }
-
-                if (p.action.refinements.is_none()) && (p.action.included_in.is_none()) && (p.action.implies.len() == 0) {
-                    prohibition_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
-                } else {
-                    let action_map = serialize_action(&p.action);
-                    prohibition_map.insert("action".to_string(), serde_json::Value::Object(action_map));
-                }
-
-                if p.constraints.len() != 0 {
-                    let serialized_constraints = serialize_constraint(&p.constraints);
-                    prohibition_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
-                }
-
+                let prohibition_map = serialize_prohibition(p);
                 serde_json::Value::Object(prohibition_map)
             }).collect();
             state.serialize_field("prohibition", &serialized_prohibitions)?;
@@ -387,4 +343,54 @@ fn serialize_permission(permission: &Permission) -> serde_json::Map<String, serd
     }
 
     permission_map
+}
+
+
+fn serialize_prohibition(prohibition: &Prohibition) -> serde_json::Map<String, serde_json::Value> {
+    let mut prohibition_map = serde_json::Map::new();
+
+    let mut target_map = serde_json::Map::new();
+    if let Some(target_type) = &prohibition.target.edc_type {
+        target_map.insert("@type".to_string(), serde_json::json!(target_type));
+    }
+    if let Some(target_uid) = &prohibition.target.uid {
+        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
+    }
+    if target_map.len() > 1 {
+        prohibition_map.insert("target".to_string(), serde_json::Value::Object(target_map));
+    } else {
+        prohibition_map.insert("target".to_string(), serde_json::json!(prohibition.target.uid.as_ref().unwrap_or(&String::new())));
+    }
+
+    if let Some(assigner) = &prohibition.assigner {
+        let assigner_map = serialize_party(assigner);
+        if assigner_map.len() > 1 {
+            prohibition_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+        } else {
+            prohibition_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
+        }
+    }
+
+    if let Some(assignee) = &prohibition.assignee {
+        let assignee_map = serialize_party(assignee);
+        if assignee_map.len() > 1 {
+            prohibition_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
+        } else {
+            prohibition_map.insert("assignee".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
+        }
+    }
+
+    if (prohibition.action.refinements.is_none()) && (prohibition.action.included_in.is_none()) && (prohibition.action.implies.len() == 0) {
+        prohibition_map.insert("action".to_string(), serde_json::json!(prohibition.action.name.clone()));
+    } else {
+        let action_map = serialize_action(&prohibition.action);
+        prohibition_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+    }
+
+    if prohibition.constraints.len() != 0 {
+        let serialized_constraints = serialize_constraint(&prohibition.constraints);
+        prohibition_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
+    }
+
+    prohibition_map
 }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -219,52 +219,48 @@ impl Serialize for SetPolicy {
                     obligation_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
                 }
 
-                if let Some(assigner) = &p.assigner {
-                    let mut assigner_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assigner.r#type {
-                        assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assigner.uid {
-                        assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assigner.part_of.len() > 0 {
-                        if assigner.part_of.len() == 1 {
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
-                    if assigner_map.len() > 1 {
-                        obligation_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+                let mut assigner_map = serde_json::Map::new();
+                if let Some(assigner_type) = &p.assigner.r#type {
+                    assigner_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                }
+                if let Some(assigner_uid) = &p.assigner.uid {
+                    assigner_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                }
+                if p.assigner.part_of.len() > 0 {
+                    if p.assigner.part_of.len() == 1 {
+                        assigner_map.insert("partOf".to_string(), serde_json::json!(p.assigner.part_of[0].source.as_ref().unwrap_or(&String::new())));
                     } else {
-                        obligation_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
+                        // Collect all PartyCollection.source into a vec
+                        let part_of: Vec<_> = p.assigner.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                        assigner_map.insert("partOf".to_string(), serde_json::json!(part_of));
                     }
                 }
+                if assigner_map.len() > 1 {
+                    obligation_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+                } else {
+                    obligation_map.insert("assigner".to_string(), serde_json::json!(p.assigner.uid.as_ref().unwrap_or(&String::new())));
+                }
 
-                if let Some(assignee) = &p.assignee {
-                    let mut assignee_map = serde_json::Map::new();
-                    if let Some(assigner_type) = &assignee.r#type {
-                        assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
-                    }
-                    if let Some(assigner_uid) = &assignee.uid {
-                        assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
-                    }
-                    if assignee.part_of.len() > 0 {
-                        if assignee.part_of.len() == 1 {
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
-                        } else {
-                            // Collect all PartyCollection.source into a vec
-                            let part_of: Vec<_> = assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
-                            assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
-                        }
-                    }
-                    if assignee_map.len() > 1 {
-                        obligation_map.insert("assigner".to_string(), serde_json::Value::Object(assignee_map));
+                let mut assignee_map = serde_json::Map::new();
+                if let Some(assigner_type) = &p.assignee.r#type {
+                    assignee_map.insert("@type".to_string(), serde_json::json!(assigner_type));
+                }
+                if let Some(assigner_uid) = &p.assignee.uid {
+                    assignee_map.insert("uid".to_string(), serde_json::json!(assigner_uid));
+                }
+                if p.assignee.part_of.len() > 0 {
+                    if p.assignee.part_of.len() == 1 {
+                        assignee_map.insert("partOf".to_string(), serde_json::json!(p.assignee.part_of[0].source.as_ref().unwrap_or(&String::new())));
                     } else {
-                        obligation_map.insert("assigner".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
+                        // Collect all PartyCollection.source into a vec
+                        let part_of: Vec<_> = p.assignee.part_of.iter().filter_map(|pc| pc.source.as_ref()).collect();
+                        assignee_map.insert("partOf".to_string(), serde_json::json!(part_of));
                     }
+                }
+                if assignee_map.len() > 1 {
+                    obligation_map.insert("assigner".to_string(), serde_json::Value::Object(assignee_map));
+                } else {
+                    obligation_map.insert("assigner".to_string(), serde_json::json!(p.assignee.uid.as_ref().unwrap_or(&String::new())));
                 }
 
                 obligation_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -345,6 +345,11 @@ fn serialize_prohibition(prohibition: &Prohibition) -> serde_json::Map<String, s
         prohibition_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
     }
 
+    if prohibition.remedies.len() != 0 {
+        let serialized_duties = serialize_duty(&prohibition.remedies);
+        prohibition.insert("remedy".to_string(), serde_json::json!(serialized_duties));
+    }
+
     prohibition_map
 }
 

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -108,7 +108,22 @@ impl Serialize for SetPolicy {
                     }
                 }
 
-                permission_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                if (p.action.refinements.is_none()) && (p.action.included_in.is_none()) && (p.action.implies.len() == 0) {
+                    permission_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                } else {
+                    let mut action_map = serde_json::Map::new();
+                    action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
+                    if let Some(refinements) = &p.action.refinements {
+                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                    }
+                    if let Some(included_in) = &p.action.included_in {
+                        action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
+                    }
+                    if p.action.implies.len() > 0 {
+                        action_map.insert("implies".to_string(), serde_json::json!(p.action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
+                    }
+                    permission_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+                }
 
                 serde_json::Value::Object(permission_map)
             }).collect();
@@ -188,7 +203,22 @@ impl Serialize for SetPolicy {
                     }
                 }
 
-                prohibition_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                if (p.action.refinements.is_none()) && (p.action.included_in.is_none()) && (p.action.implies.len() == 0) {
+                    prohibition_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                } else {
+                    let mut action_map = serde_json::Map::new();
+                    action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
+                    if let Some(refinements) = &p.action.refinements {
+                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                    }
+                    if let Some(included_in) = &p.action.included_in {
+                        action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
+                    }
+                    if p.action.implies.len() > 0 {
+                        action_map.insert("implies".to_string(), serde_json::json!(p.action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
+                    }
+                    prohibition_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+                }
 
                 serde_json::Value::Object(prohibition_map)
             }).collect();
@@ -262,7 +292,22 @@ impl Serialize for SetPolicy {
                     obligation_map.insert("assignee".to_string(), serde_json::json!(p.assignee.uid.as_ref().unwrap_or(&String::new())));
                 }
 
-                obligation_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                if (p.action.refinements.is_none()) && (p.action.included_in.is_none()) && (p.action.implies.len() == 0) {
+                    obligation_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
+                } else {
+                    let mut action_map = serde_json::Map::new();
+                    action_map.insert("name".to_string(), serde_json::json!(p.action.name.clone()));
+                    if let Some(refinements) = &p.action.refinements {
+                        action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                    }
+                    if let Some(included_in) = &p.action.included_in {
+                        action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
+                    }
+                    if p.action.implies.len() > 0 {
+                        action_map.insert("implies".to_string(), serde_json::json!(p.action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
+                    }
+                    obligation_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+                }
 
                 // collect all consequences
                 let serialized_consequences: Vec<_> = p.consequence.iter().map(|d| {
@@ -270,7 +315,23 @@ impl Serialize for SetPolicy {
                     if let Some(uid) = &d.uid {
                         consequence_map.insert("uid".to_string(), serde_json::json!(uid));
                     }
-                    consequence_map.insert("action".to_string(), serde_json::json!(d.action.name.clone()));;
+                    if d.action.refinements.is_none() && d.action.included_in.is_none() && d.action.implies.len() == 0 {
+                        consequence_map.insert("action".to_string(), serde_json::json!(d.action.name.clone()));
+                    } else {
+                        let mut action_map = serde_json::Map::new();
+                        action_map.insert("name".to_string(), serde_json::json!(d.action.name.clone()));
+                        if let Some(refinements) = &d.action.refinements {
+                            // TODO remove some of the field names
+                            action_map.insert("refinement".to_string(), serde_json::json!(refinements));
+                        }
+                        if let Some(included_in) = &d.action.included_in {
+                            action_map.insert("includedIn".to_string(), serde_json::json!(included_in));
+                        }
+                        if d.action.implies.len() > 0 {
+                            action_map.insert("implies".to_string(), serde_json::json!(d.action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
+                        }
+                        consequence_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+                    }
                     if let Some(relation) = &d.relation {
                         consequence_map.insert("relation".to_string(), serde_json::json!(relation.uid.as_ref().unwrap_or(&String::new())));
                     }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -47,51 +47,7 @@ impl Serialize for SetPolicy {
 
         if !permissions.is_empty() {
             let serialized_permissions: Vec<_> = permissions.iter().map(|p| {
-                let mut permission_map = serde_json::Map::new();
-
-                let mut target_map = serde_json::Map::new();
-                if let Some(target_type) = &p.target.edc_type {
-                    target_map.insert("@type".to_string(), serde_json::json!(target_type));
-                }
-                if let Some(target_uid) = &p.target.uid {
-                    target_map.insert("uid".to_string(), serde_json::json!(target_uid));
-                }
-                if target_map.len() > 1 {
-                    permission_map.insert("target".to_string(), serde_json::Value::Object(target_map));
-                } else {
-                    permission_map.insert("target".to_string(), serde_json::json!(p.target.uid.as_ref().unwrap_or(&String::new())));
-                }
-
-                if let Some(assigner) = &p.assigner {
-                    let assigner_map = serialize_party(assigner);
-                    if assigner_map.len() > 1 {
-                        permission_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
-                    } else {
-                        permission_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
-                    }
-                }
-
-                if let Some(assignee) = &p.assignee {
-                    let assignee_map = serialize_party(assignee);
-                    if assignee_map.len() > 1 {
-                        permission_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
-                    } else {
-                        permission_map.insert("assignee".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
-                    }
-                }
-
-                if (p.action.refinements.is_none()) && (p.action.included_in.is_none()) && (p.action.implies.len() == 0) {
-                    permission_map.insert("action".to_string(), serde_json::json!(p.action.name.clone()));
-                } else {
-                    let action_map = serialize_action(&p.action);
-                    permission_map.insert("action".to_string(), serde_json::Value::Object(action_map));
-                }
-
-                if p.constraints.len() != 0 {
-                    let serialized_constraints = serialize_constraint(&p.constraints);
-                    permission_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
-                }
-
+                let permission_map = serialize_permission(p);
                 serde_json::Value::Object(permission_map)
             }).collect();
             state.serialize_field("permission", &serialized_permissions)?;
@@ -381,4 +337,54 @@ fn serialize_party(party: &Party) -> serde_json::Map<String, serde_json::Value> 
     }
 
     assigner_map
+}
+
+
+fn serialize_permission(permission: &Permission) -> serde_json::Map<String, serde_json::Value> {
+    let mut permission_map = serde_json::Map::new();
+
+    let mut target_map = serde_json::Map::new();
+    if let Some(target_type) = &permission.target.edc_type {
+        target_map.insert("@type".to_string(), serde_json::json!(target_type));
+    }
+    if let Some(target_uid) = &permission.target.uid {
+        target_map.insert("uid".to_string(), serde_json::json!(target_uid));
+    }
+    if target_map.len() > 1 {
+        permission_map.insert("target".to_string(), serde_json::Value::Object(target_map));
+    } else {
+        permission_map.insert("target".to_string(), serde_json::json!(permission.target.uid.as_ref().unwrap_or(&String::new())));
+    }
+
+    if let Some(assigner) = &permission.assigner {
+        let assigner_map = serialize_party(assigner);
+        if assigner_map.len() > 1 {
+            permission_map.insert("assigner".to_string(), serde_json::Value::Object(assigner_map));
+        } else {
+            permission_map.insert("assigner".to_string(), serde_json::json!(assigner.uid.as_ref().unwrap_or(&String::new())));
+        }
+    }
+
+    if let Some(assignee) = &permission.assignee {
+        let assignee_map = serialize_party(assignee);
+        if assignee_map.len() > 1 {
+            permission_map.insert("assignee".to_string(), serde_json::Value::Object(assignee_map));
+        } else {
+            permission_map.insert("assignee".to_string(), serde_json::json!(assignee.uid.as_ref().unwrap_or(&String::new())));
+        }
+    }
+
+    if (permission.action.refinements.is_none()) && (permission.action.included_in.is_none()) && (permission.action.implies.len() == 0) {
+        permission_map.insert("action".to_string(), serde_json::json!(permission.action.name.clone()));
+    } else {
+        let action_map = serialize_action(&permission.action);
+        permission_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+    }
+
+    if permission.constraints.len() != 0 {
+        let serialized_constraints = serialize_constraint(&permission.constraints);
+        permission_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
+    }
+
+    permission_map
 }

--- a/crates/odrl/src/functions/json_serializer.rs
+++ b/crates/odrl/src/functions/json_serializer.rs
@@ -180,6 +180,49 @@ impl Serialize for SetPolicy {
                     permission_map.insert("action".to_string(), serde_json::Value::Object(action_map));
                 }
 
+                if p.constraints.len() != 0 {
+                    let mut serialized_constraints = Vec::new();
+                    for constraint in &p.constraints {
+                        let mut constraint_map = serde_json::Map::new();
+                        // differentiate between literal and iri operands
+                        match &constraint.left_operand {
+                            LeftOperand::Literal(literal) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                            },
+                            LeftOperand::IRI(iri) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                            }
+                            LeftOperand::Reference(reference) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                            }
+                        }
+                        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                        // differentiate between literal and iri operands
+                        match &constraint.right_operand {
+                            RightOperand::Literal(literal) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                            },
+                            RightOperand::IRI(iri) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                            }
+                            RightOperand::Reference(reference) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                            }
+                        }
+                        if let Some(data_type) = &constraint.data_type {
+                            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                        }
+                        if let Some(unit) = &constraint.unit {
+                            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                        }
+                        if !constraint.status.is_empty() {
+                            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                        }
+                        serialized_constraints.push(constraint_map);
+                    }
+                    permission_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
+                }
+
                 serde_json::Value::Object(permission_map)
             }).collect();
             state.serialize_field("permission", &serialized_permissions)?;
@@ -327,6 +370,49 @@ impl Serialize for SetPolicy {
                         action_map.insert("implies".to_string(), serde_json::json!(p.action.implies.iter().map(|a| a.name.clone()).collect::<Vec<_>>()));
                     }
                     prohibition_map.insert("action".to_string(), serde_json::Value::Object(action_map));
+                }
+
+                if p.constraints.len() != 0 {
+                    let mut serialized_constraints = Vec::new();
+                    for constraint in &p.constraints {
+                        let mut constraint_map = serde_json::Map::new();
+                        // differentiate between literal and iri operands
+                        match &constraint.left_operand {
+                            LeftOperand::Literal(literal) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(literal));
+                            },
+                            LeftOperand::IRI(iri) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(iri));
+                            }
+                            LeftOperand::Reference(reference) => {
+                                constraint_map.insert("leftOperand".to_string(), serde_json::json!(reference));
+                            }
+                        }
+                        constraint_map.insert("operator".to_string(), serde_json::json!(constraint.operator));
+                        // differentiate between literal and iri operands
+                        match &constraint.right_operand {
+                            RightOperand::Literal(literal) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(literal));
+                            },
+                            RightOperand::IRI(iri) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(iri));
+                            }
+                            RightOperand::Reference(reference) => {
+                                constraint_map.insert("rightOperand".to_string(), serde_json::json!(reference));
+                            }
+                        }
+                        if let Some(data_type) = &constraint.data_type {
+                            constraint_map.insert("dataType".to_string(), serde_json::json!(data_type));
+                        }
+                        if let Some(unit) = &constraint.unit {
+                            constraint_map.insert("unit".to_string(), serde_json::json!(unit));
+                        }
+                        if !constraint.status.is_empty() {
+                            constraint_map.insert("status".to_string(), serde_json::json!(constraint.status));
+                        }
+                        serialized_constraints.push(constraint_map);
+                    }
+                    prohibition_map.insert("constraint".to_string(), serde_json::json!(serialized_constraints));
                 }
 
                 serde_json::Value::Object(prohibition_map)

--- a/crates/odrl/src/model/party.rs
+++ b/crates/odrl/src/model/party.rs
@@ -18,6 +18,22 @@ impl Default for Function {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PartyType {
+
+    #[serde(rename = "Party")]
+    Party,
+    #[serde(rename = "PartyCollection")]
+    PartyCollection,
+
+}
+
+impl Default for PartyType {
+    fn default() -> PartyType {
+        PartyType::Party
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Party {
 
@@ -27,16 +43,19 @@ pub struct Party {
     pub part_of: Vec<PartyCollection>,
     #[serde(skip_serializing)]
     pub function: Function,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<PartyType>,
 
 }
 
 impl Party {
 
-    pub fn new(uid: Option<IRI>, part_of: Vec<PartyCollection>, function: Function) -> Party {
+    pub fn new(uid: Option<IRI>, part_of: Vec<PartyCollection>, function: Function, r#type: Option<PartyType>) -> Party {
         Party {
             uid,
             part_of,
-            function
+            function,
+            r#type
         }
     }
 

--- a/crates/odrl/src/model/party.rs
+++ b/crates/odrl/src/model/party.rs
@@ -22,15 +22,15 @@ impl Default for Function {
 pub enum PartyType {
 
     #[serde(rename = "Party")]
-    Party,
+    Party(Vec<String>),
     #[serde(rename = "PartyCollection")]
-    PartyCollection,
+    PartyCollection(Vec<String>),
 
 }
 
 impl Default for PartyType {
     fn default() -> PartyType {
-        PartyType::Party
+        PartyType::Party(vec!["Party".to_string(), "vcard:Individual".to_string()])
     }
 }
 
@@ -43,7 +43,7 @@ pub struct Party {
     pub part_of: Vec<PartyCollection>,
     #[serde(skip_serializing)]
     pub function: Function,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@type", skip_serializing_if = "Option::is_none")]
     pub r#type: Option<PartyType>,
 
 }

--- a/crates/odrl/src/model/party.rs
+++ b/crates/odrl/src/model/party.rs
@@ -44,18 +44,18 @@ pub struct Party {
     #[serde(skip_serializing)]
     pub function: Function,
     #[serde(rename = "@type", skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<PartyType>,
+    pub party_type: Option<PartyType>,
 
 }
 
 impl Party {
 
-    pub fn new(uid: Option<IRI>, part_of: Vec<PartyCollection>, function: Function, r#type: Option<PartyType>) -> Party {
+    pub fn new(uid: Option<IRI>, part_of: Vec<PartyCollection>, function: Function, party_type: Option<PartyType>) -> Party {
         Party {
             uid,
             part_of,
             function,
-            r#type
+            party_type
         }
     }
 

--- a/crates/odrl/src/model/policy.rs
+++ b/crates/odrl/src/model/policy.rs
@@ -8,7 +8,7 @@ use crate::model::type_alias::IRI;
 
 
 /// Default Policy of type Set
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 pub struct SetPolicy {
 
     pub uid: IRI,
@@ -40,7 +40,7 @@ impl SetPolicy {
 
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 pub struct OfferPolicy {
 
     pub uid: IRI,
@@ -75,7 +75,7 @@ impl OfferPolicy {
 
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 pub struct AgreementPolicy {
 
     pub uid: IRI,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,3 +33,7 @@ path = "edc_api/edc_api_test.rs"
 [[test]]
 name = "odrl_json_parser_test"
 path = "odrl/json_parser_test.rs"
+
+[[test]]
+name = "odrl_json_serializer_test"
+path = "odrl/json_serializer_test.rs"

--- a/tests/odrl/json_serializer_test.rs
+++ b/tests/odrl/json_serializer_test.rs
@@ -1,0 +1,42 @@
+// Examples based on https://www.w3.org/TR/odrl-model
+
+#[cfg(test)]
+mod json_ld_serializer_test {
+    extern crate odrl;
+
+    use odrl::model::policy::{SetPolicy};
+    use odrl::model::rule::{Rule, Permission};
+    use odrl::model::action::Action;
+    use odrl::model::asset::Asset;
+
+    #[test]
+    fn test_set_policy_with_one_rule_serialize() {
+        let action = Action::new("use", None, None, vec![]);
+        let mut asset = Asset::default();
+        asset.uid = Some("https://example.com/asset:9898.movie".to_string());
+        let mut permission = Permission::default();
+        permission.target = asset;
+        permission.action = action;
+
+        let mut policy = SetPolicy::default();
+        policy.uid = "https://example.com/policy:1010".to_string();
+        policy.rules = vec![Rule::Permission(permission)];
+
+        let serialized_policy = serde_json::to_string_pretty(&policy).unwrap();
+        let expected_policy = r#"
+        {
+            "@type": "Set",
+            "uid": "https://example.com/policy:1010",
+            "permission": [{
+            "target": "https://example.com/asset:9898.movie",
+            "action": "use"
+            }]
+        }"#.to_string();
+
+        assert_eq!(
+            serialized_policy.parse::<serde_json::Value>().unwrap(),
+            expected_policy.parse::<serde_json::Value>().unwrap()
+        );
+    }
+
+}

--- a/tests/odrl/json_serializer_test.rs
+++ b/tests/odrl/json_serializer_test.rs
@@ -1,7 +1,7 @@
 // Examples based on https://www.w3.org/TR/odrl-model
 
 #[cfg(test)]
-mod json_ld_serializer_test {
+mod json_serializer_test {
     extern crate odrl;
 
     use odrl::model::action::{Action, Refinements};

--- a/tests/odrl/json_serializer_test.rs
+++ b/tests/odrl/json_serializer_test.rs
@@ -8,7 +8,7 @@ mod json_ld_serializer_test {
     use odrl::model::asset::Asset;
     use odrl::model::constraint::{Constraint, LeftOperand, Operator, RightOperand, LogicalConstraint, LogicalOperator};
     use odrl::model::party::Party;
-    use odrl::model::policy::{SetPolicy};
+    use odrl::model::policy::{SetPolicy, OfferPolicy};
     use odrl::model::rule::{Rule, Permission, Prohibition, Obligation, Duty};
 
     #[test]
@@ -234,6 +234,43 @@ mod json_ld_serializer_test {
                     "target": "https://example.com/document:XZY"
                 }
             ]
+        }"#.to_string();
+
+        assert_eq!(
+            serialized_policy.parse::<serde_json::Value>().unwrap(),
+            expected_policy.parse::<serde_json::Value>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_offer_policy_serialize() {
+        let action = Action::new("play", None, None, vec![]);
+        let mut asset = Asset::default();
+        asset.uid = Some("https://example.com/asset:9898.movie".to_string());
+        let mut permission = Permission::default();
+        permission.target = asset;
+        permission.action = action;
+
+        let mut assigner = Party::default();
+        assigner.uid = Some("https://example.com/party:org:abc".to_string());
+
+        let mut policy = OfferPolicy::default();
+        policy.uid = "https://example.com/policy:1011".to_string();
+        policy.rules = vec![Rule::Permission(permission)];
+        policy.assigner = assigner;
+        policy.profiles = vec!["https://example.com/odrl:profile:01".to_string()];
+
+        let serialized_policy = serde_json::to_string_pretty(&policy).unwrap();
+        let expected_policy = r#"
+        {
+            "@type": "Offer",
+            "uid": "https://example.com/policy:1011",
+            "profile": "https://example.com/odrl:profile:01",
+            "assigner": "https://example.com/party:org:abc",
+            "permission": [{
+                "target": "https://example.com/asset:9898.movie",
+                "action": "play"
+            }]
         }"#.to_string();
 
         assert_eq!(

--- a/tests/odrl/json_serializer_test.rs
+++ b/tests/odrl/json_serializer_test.rs
@@ -4,10 +4,12 @@
 mod json_ld_serializer_test {
     extern crate odrl;
 
-    use odrl::model::policy::{SetPolicy};
-    use odrl::model::rule::{Rule, Permission};
-    use odrl::model::action::Action;
+    use odrl::model::action::{Action, Refinements};
     use odrl::model::asset::Asset;
+    use odrl::model::constraint::{Constraint, LeftOperand, Operator, RightOperand, LogicalConstraint, LogicalOperator};
+    use odrl::model::party::Party;
+    use odrl::model::policy::{SetPolicy};
+    use odrl::model::rule::{Rule, Permission, Prohibition, Obligation, Duty};
 
     #[test]
     fn test_set_policy_with_one_rule_serialize() {
@@ -64,14 +66,174 @@ mod json_ld_serializer_test {
         {
             "@type": "Set",
             "uid": "https://example.com/policy:1010",
-            "permission": [{
-            "target": "https://example.com/asset:9898.movie",
-            "action": "play"
-            },
-            {
-            "target": "https://example.com/asset:1212",
-            "action": "use"
-            }]
+            "permission": [
+                {
+                    "target": "https://example.com/asset:9898.movie",
+                    "action": "play"
+                },
+                {
+                    "target": "https://example.com/asset:1212",
+                    "action": "use"
+                }
+            ]
+        }"#.to_string();
+
+        assert_eq!(
+            serialized_policy.parse::<serde_json::Value>().unwrap(),
+            expected_policy.parse::<serde_json::Value>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_set_policy_with_several_complex_rules_serialize() {
+
+        // Permission 1
+        let mut asset_1 = Asset::default();
+        asset_1.uid = Some("https://example.com/asset:9898.movie".to_string());
+        let mut party_1 = Party::default();
+        party_1.uid = Some("https://example.com/party:org:abc".to_string());
+        let action_1 = Action::new("play", None, None, vec![]);
+        let mut permission_1 = Permission::default();
+        permission_1.target = asset_1;
+        permission_1.assigner = Some(party_1);
+        permission_1.action = action_1;
+
+        // Permission 2
+        let mut asset_2 = Asset::default();
+        asset_2.uid = Some("https://example.com/asset:1212".to_string());
+        let mut party_2 = Party::default();
+        party_2.uid = Some("https://example.com/owner:182".to_string());
+        let mut action_2 = Action::default();
+        action_2.name = "display".to_string();
+        let mut permission_2 = Permission::default();
+        permission_2.target = asset_2.clone();
+        permission_2.assigner = Some(party_2);
+        permission_2.action = action_2;
+
+        // Prohibition 1
+        let mut action_3 = Action::default();
+        action_3.name = "print".to_string();
+        let mut prohibition_1 = Prohibition::default();
+        prohibition_1.target = asset_2.clone();
+        prohibition_1.action = action_3;
+
+        // Permission 3 with Constraints
+        let mut asset_3 = Asset::default();
+        asset_3.uid = Some("https://example.com/document:1234".to_string());
+        let mut party_3 = Party::default();
+        party_3.uid = Some("https://example.com/org:616".to_string());
+        let mut action_4 = Action::default();
+        action_4.name = "distribute".to_string();
+        let mut permission_constraint = Constraint::default();
+        permission_constraint.left_operand = LeftOperand::Literal("dateTime".to_string());
+        permission_constraint.operator = Operator::LessThan;
+        permission_constraint.right_operand = RightOperand::Literal("2018-01-01".to_string());
+        let mut permission_3 = Permission::default();
+        permission_3.target = asset_3.clone();
+        permission_3.assigner = Some(party_3);
+        permission_3.action = action_4;
+        permission_3.constraints = vec![permission_constraint];
+
+        // Obligation 1
+        let mut obligation_action = Action::default();
+        obligation_action.name = "delete".to_string();
+        let mut obligation_asset = Asset::default();
+        obligation_asset.uid = Some("https://example.com/document:XZY".to_string());
+        let mut obligation_assigner = Party::default();
+        obligation_assigner.uid = Some("https://example.com/org:43".to_string());
+        let mut obligation_assignee = Party::default();
+        obligation_assignee.uid = Some("https://example.com/person:44".to_string());
+
+        // Obligation 2 with action refinement
+        let mut consequence = Duty::default();
+        let mut consequence_action = Action::default();
+        let mut action_refinement = Refinements::default();
+        let mut refinement_constraint = Constraint::default();
+        refinement_constraint.left_operand = LeftOperand::Literal("payAmount".to_string());
+        refinement_constraint.operator = Operator::Equal;
+        refinement_constraint.right_operand = RightOperand::Literal("10.00".to_string());
+        refinement_constraint.unit = Some("https://dbpedia.org/resource/Euro".to_string());
+        let mut refinement_logical = LogicalConstraint::default();
+        let c1_iri = "https://example.com/p:88/C1".to_string();
+        let c2_iri = "https://example.com/p:88/C2".to_string();
+        refinement_logical.operand = Some((LogicalOperator::Xone, vec![c1_iri, c2_iri]));
+        action_refinement = Refinements::Constraints(vec![refinement_constraint]);
+        consequence_action.name = "compensate".to_string();
+        consequence_action.refinements = Some(action_refinement);
+        let mut consequence_party = Party::default();
+        consequence_party.uid = Some("https://wwf.org".to_string());
+        consequence.function = vec![consequence_party];
+        consequence.action = consequence_action;
+        let mut obligation_1 = Obligation::default();
+        obligation_1.action = obligation_action;
+        obligation_1.target = obligation_asset;
+        obligation_1.consequence = vec![consequence];
+        obligation_1.assigner = obligation_assigner;
+        obligation_1.assignee = obligation_assignee;
+
+        let mut policy = SetPolicy::default();
+        policy.uid = "https://example.com/policy:1011".to_string();
+        policy.profiles = vec!["https://example.com/odrl:profile:01".to_string()];
+        policy.rules = vec![Rule::Permission(permission_1), Rule::Permission(permission_2), Rule::Permission(permission_3), Rule::Prohibition(prohibition_1), Rule::Obligation(obligation_1)];
+        let serialized_policy = serde_json::to_string_pretty(&policy).unwrap();
+
+        let expected_policy = r#"
+        {
+            "@type": "Set",
+            "uid": "https://example.com/policy:1011",
+            "profile": "https://example.com/odrl:profile:01",
+            "permission": [
+                {
+                    "action": "play",
+                    "assigner": "https://example.com/party:org:abc",
+                    "target": "https://example.com/asset:9898.movie"
+                },
+                {
+                    "action": "display",
+                    "assigner": "https://example.com/owner:182",
+                    "target": "https://example.com/asset:1212"
+                },
+                {
+                    "action": "distribute",
+                    "assigner": "https://example.com/org:616",
+                    "constraint": [
+                        {
+                            "leftOperand": "dateTime",
+                            "operator": "lt",
+                            "rightOperand": "2018-01-01"
+                        }
+                    ],
+                    "target": "https://example.com/document:1234"
+                }
+            ],
+            "prohibition": [
+                {
+                    "action": "print",
+                    "target": "https://example.com/asset:1212"
+                }
+            ],
+            "obligation": [
+                {
+                    "action": "delete",
+                    "assignee": "https://example.com/person:44",
+                    "assigner": "https://example.com/org:43",
+                    "consequence": [
+                        {
+                            "action": {
+                                "name": "compensate",
+                                "refinement": [{
+                                    "leftOperand": "payAmount",
+                                    "operator": "eq",
+                                    "rightOperand": "10.00",
+                                    "unit": "https://dbpedia.org/resource/Euro"
+                                }]
+                            },
+                            "compensatedParty": "https://wwf.org"
+                        }
+                    ],
+                    "target": "https://example.com/document:XZY"
+                }
+            ]
         }"#.to_string();
 
         assert_eq!(

--- a/tests/odrl/json_serializer_test.rs
+++ b/tests/odrl/json_serializer_test.rs
@@ -39,4 +39,45 @@ mod json_ld_serializer_test {
         );
     }
 
+    #[test]
+    fn test_set_policy_with_two_rules_serialize() {
+        let action_1 = Action::new("play", None, None, vec![]);
+        let mut asset_1 = Asset::default();
+        asset_1.uid = Some("https://example.com/asset:9898.movie".to_string());
+        let mut permission_1 = Permission::default();
+        permission_1.target = asset_1;
+        permission_1.action = action_1;
+
+        let action_2 = Action::new("use", None, None, vec![]);
+        let mut asset_2 = Asset::default();
+        asset_2.uid = Some("https://example.com/asset:1212".to_string());
+        let mut permission_2 = Permission::default();
+        permission_2.target = asset_2;
+        permission_2.action = action_2;
+
+        let mut policy = SetPolicy::default();
+        policy.uid = "https://example.com/policy:1010".to_string();
+        policy.rules = vec![Rule::Permission(permission_1), Rule::Permission(permission_2)];
+
+        let serialized_policy = serde_json::to_string_pretty(&policy).unwrap();
+        let expected_policy = r#"
+        {
+            "@type": "Set",
+            "uid": "https://example.com/policy:1010",
+            "permission": [{
+            "target": "https://example.com/asset:9898.movie",
+            "action": "play"
+            },
+            {
+            "target": "https://example.com/asset:1212",
+            "action": "use"
+            }]
+        }"#.to_string();
+
+        assert_eq!(
+            serialized_policy.parse::<serde_json::Value>().unwrap(),
+            expected_policy.parse::<serde_json::Value>().unwrap()
+        );
+    }
+
 }


### PR DESCRIPTION
This pull request introduces the implementation of manual serialization of policies. This is needed, since rules are not represented as "rule: [...]" in json but as lists of permission, prohibition, obligation and duty. 

In addition to the implementation of the serialization, unit testing is included.

**Changes:**

- Add manual Serialization of policies
- Rules are represented as lists of permission, prohibition, obligation and duty in json
- Add Tests